### PR TITLE
Send stats on interval 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0)
 #TODO bump to a newer version that works with the below as minimum
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
+project(uplink C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -13,6 +15,10 @@ endif()
 
 add_definitions(-DARCH_${ARCH})
 add_definitions(-DARCH="${ARCH}")
+
+set(TRIPLE "${ARCH}-pc-linux-elf")
+set(CMAKE_CXX_COMPILER_TARGET ${TRIPLE})
+set(CMAKE_C_COMPILER_TARGET ${TRIPLE})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 

--- a/include/uplink/config.hpp
+++ b/include/uplink/config.hpp
@@ -39,6 +39,7 @@ namespace uplink {
     bool        reboot        = true;
     bool        ws_logging    = true;
     bool        serialize_ct  = false;
+    int         send_stats    = 0;
 
     static Config read();
 

--- a/include/uplink/ws_uplink.hpp
+++ b/include/uplink/ws_uplink.hpp
@@ -93,6 +93,8 @@ private:
   Timer heartbeat_timer;
   RTC::timestamp_t last_ping;
 
+  Timer stats_timer;
+
   RTC::timestamp_t update_time_taken = 0;
 
   void inject_token(http::Request& req, http::Basic_client::Options&, const http::Basic_client::Host)
@@ -117,6 +119,13 @@ private:
   bool missing_heartbeat()
   { return last_ping < RTC::now() - heartbeat_interval.count(); }
   void on_heartbeat_timer();
+
+  void send_stats_interval()
+  {
+    Expects(config_.send_stats > 0);
+    send_stats();
+    stats_timer.start(std::chrono::milliseconds(config_.send_stats));
+  }
 
   void parse_transport(net::WebSocket::Message_ptr msg);
 #if defined(LIVEUPDATE)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -114,6 +114,11 @@ namespace uplink {
       config_.verify_certs = cfg["verify"].GetBool();
     }
 
+    if(cfg.HasMember("send_stats"))
+    {
+      config_.send_stats = cfg["send_stats"].GetInt();
+    }
+
     return config_;
   }
 
@@ -151,6 +156,9 @@ namespace uplink {
 
     writer.Key("serialize_ct");
     writer.Bool(serialize_ct);
+
+    writer.Key("send_stats");
+    writer.Int(send_stats);
 
     writer.EndObject();
 

--- a/src/ws_uplink.cpp
+++ b/src/ws_uplink.cpp
@@ -634,6 +634,14 @@ namespace uplink {
     writer.Int64(system_ms);
     writer.EndObject();
 
+
+    writer.StartObject();
+    writer.Key("name");
+    writer.String("total_memuse");
+    writer.Key("value");
+    writer.Uint64(os::total_memuse());
+    writer.EndObject();
+
     auto& statman = Statman::get();
     for(auto it = statman.begin(); it != statman.end(); ++it)
     {

--- a/src/ws_uplink.cpp
+++ b/src/ws_uplink.cpp
@@ -616,6 +616,24 @@ namespace uplink {
     Writer<StringBuffer> writer{buf};
 
     writer.StartArray();
+
+    using namespace std::chrono;
+    writer.StartObject();
+    int64_t steady_ms = duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+    writer.Key("name");
+    writer.String("monolitic_ts_ms");
+    writer.Key("value");
+    writer.Int64(steady_ms);
+    writer.EndObject();
+
+    writer.StartObject();
+    int64_t system_ms = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+    writer.Key("name");
+    writer.String("rtc_ts_ms");
+    writer.Key("value");
+    writer.Int64(system_ms);
+    writer.EndObject();
+
     auto& statman = Statman::get();
     for(auto it = statman.begin(); it != statman.end(); ++it)
     {


### PR DESCRIPTION
Default off, can be turned on in config:
```
    "uplink" : {
      "send_stats": 1000
    }
```
(The value is in milliseconds)